### PR TITLE
corrected DownloadAddressBookEntryAsync catch statement

### DIFF
--- a/src/IronPigeon/OnlineAddressBook.cs
+++ b/src/IronPigeon/OnlineAddressBook.cs
@@ -63,7 +63,7 @@ namespace IronPigeon
                     AddressBookEntry entry = await MessagePackSerializer.DeserializeAsync<AddressBookEntry>(stream, Utilities.MessagePackSerializerOptions, cancellationToken).ConfigureAwait(false);
                     return entry;
                 }
-                catch (SerializationException ex)
+                catch (MessagePackSerializationException ex)
                 {
                     throw new BadAddressBookEntryException(ex.Message, ex);
                 }


### PR DESCRIPTION
Corrected DownloadAddressBookEntryAsync to catch MessagePackSerializationException instead of SerializationException.

MessagePackSerializer.DeserializeAsync throws MessagePackSerializationExceptions on failure, which isn't a subclass of SerializationException. 

Without this change, serialization exceptions don't get properly wrapped in the BadAddressBookEntryException.