### PR TITLE
fix the bug in case transient errors happen

### DIFF
--- a/src/IronPigeon/Providers/AzureBlobStorage.cs
+++ b/src/IronPigeon/Providers/AzureBlobStorage.cs
@@ -165,7 +165,13 @@ namespace IronPigeon.Providers
             directoryToBlobs.Complete();
             await directoryToBlobs.Completion.ConfigureAwait(false);
             deleteBlobBlock.Complete();
-            await deleteBlobBlock.Completion.ConfigureAwait(false);
+            try
+            {
+                await deleteBlobBlock.Completion.ConfigureAwait(false);
+            }
+            catch (Azure.RequestFailedException ex) when (ex.Status == (int)System.Net.HttpStatusCode.NotFound)
+            {
+            }
         }
     }
 }


### PR DESCRIPTION
### Version

[710dcd7](https://github.com/AArnott/IronPigeon/commit/710dcd7c77efb3ac178d8cff556894d02fb6b892)

### Bug description
We found that transient network errors (e.g., network timeout or package drop) may happen when Blob is deleted via SDK API `DeleteBlobAsync` in [`PurgeBlobsExpiringBeforeAsync`](https://github.com/AArnott/IronPigeon/blob/50df84fda48dd15ce43425e62296e8e2683fbe05/src/IronPigeon/Providers/AzureBlobStorage.cs#L115), so the SDK will retry the deletion again. However, since the first request has already deleted the blob successfully, the retry request will encounter an `BlobNotFound` error.
```c#
public async Task PurgeBlobsExpiringBeforeAsync(DateTime? deleteBlobsExpiringBefore, CancellationToken cancellationToken = default) {
...
            var deleteBlobBlock = new ActionBlock<BlobItem>(              
                blob => this.container.DeleteBlobAsync(blob.Name, cancellationToken: cancellationToken), 
                new ExecutionDataflowBlockOptions
                {
                    MaxDegreeOfParallelism = 4,
                    BoundedCapacity = 100,
                    MaxMessagesPerTask = 50,
                    CancellationToken = cancellationToken,
                });
```

### How to reproduce
We find [this test](https://github.com/AArnott/IronPigeon/blob/710dcd7c77efb3ac178d8cff556894d02fb6b892/test/IronPigeon.Tests/Providers/AzureBlobStorageTests.cs#L51) could be used to reproduce the bug. After the transient error happens (network timeout or connection drop) happens, the `PurgeBlobsExpiringBeforeAsync` will fail due to BlobNotFound error. The stack trace is shown below.

<details>
<summary>Stack trace</summary>

```
Error message:
Azure.RequestFailedException : The specified blob does not exist.
RequestId:298b698d-de59-48da-a921-5578812583a7
Time:2022-06-14T02:10:01.200Z
Status: 404 (The specified blob does not exist.)
ErrorCode: BlobNotFound

Headers:
Server: Azurite-Blob/3.17.1
x-ms-error-code: BlobNotFound
x-ms-request-id: 298b698d-de59-48da-a921-5578812583a7
Date: Tue, 14 Jun 2022 02:10:01 GMT
Keep-Alive: REDACTED
Connection: keep-alive
Content-Type: application/xml
Content-Length: 233
Stack Trace:
   at Azure.Storage.Blobs.BlobRestClient.Blob.DeleteAsync_CreateResponse(ClientDiagnostics clientDiagnostics, Response response)
   at Azure.Storage.Blobs.BlobRestClient.Blob.DeleteAsync(ClientDiagnostics clientDiagnostics, HttpPipeline pipeline, Uri resourceUri, String version, String snapshot, String versionId, Nullable`1 timeout, String leaseId, Nullable`1 deleteSnapshots, Nullable`1 ifModifiedSince, Nullable`1 ifUnmodifiedSince, Nullable`1 ifMatch, Nullable`1 ifNoneMatch, String ifTags, String requestId, Nullable`1 blobDeleteType, Boolean async, String operationName, CancellationToken cancellationToken)
   at Azure.Storage.Blobs.Specialized.BlobBaseClient.DeleteInternal(DeleteSnapshotsOption snapshotsOption, BlobRequestConditions conditions, Boolean async, CancellationToken cancellationToken, String operationName)
   at Azure.Storage.Blobs.Specialized.BlobBaseClient.DeleteAsync(DeleteSnapshotsOption snapshotsOption, BlobRequestConditions conditions, CancellationToken cancellationToken)
   at Azure.Storage.Blobs.BlobContainerClient.DeleteBlobAsync(String blobName, DeleteSnapshotsOption snapshotsOption, BlobRequestConditions conditions, CancellationToken cancellationToken)
   at IronPigeon.Providers.AzureBlobStorage.PurgeBlobsExpiringBeforeAsync(Nullable`1 deleteBlobsExpiringBefore, CancellationToken cancellationToken) in C:\Users\XXX\IronPigeon\src\IronPigeon\Providers\AzureBlobStorage.cs:line 168
...
```
</details>

### Discussion
We think it would be better if we wrap the deletion with a try-catch block which will catch the exception and then ignore the 404 error when deleting. Since in the source code, there is an `ActionBlock` embedding the `DeleteBlobAsync` SDK API, we think the try-catch could be written around [`deleteBlobBlock`](https://github.com/AArnott/IronPigeon/blob/50df84fda48dd15ce43425e62296e8e2683fbe05/src/IronPigeon/Providers/AzureBlobStorage.cs#L168).